### PR TITLE
feat: module files and example app

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,0 +1,17 @@
+import { Stack, StackProps } from 'aws-cdk-lib';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import { Construct } from 'constructs';
+import * as imagedeploy from '../index';
+
+
+export class DockerImageDeploymentStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    // with tag
+    new imagedeploy.DockerImageDeployment(this, 'imagedeploywithtag', {
+      source: imagedeploy.Source.directory('src/assets'),
+      destination: imagedeploy.Destination.ecr({ repository: ecr.Repository.fromRepositoryName(this, 'mydestRepo', 'poc2destination'), tag: 'deploythis' }),
+    });
+  }
+}

--- a/src/app/runner.ts
+++ b/src/app/runner.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { DockerImageDeploymentStack } from './app';
+
+const app = new cdk.App();
+new DockerImageDeploymentStack(app, 'dockerimagedeployStack', {});

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -1,0 +1,42 @@
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+//import * as ecr_assets from 'aws-cdk-lib/aws-ecr-assets';
+//import * as iam from 'aws-cdk-lib/aws-iam';
+//import { Construct } from 'constructs';
+
+
+export interface DestinationConfig {
+  /**
+   * The URI of the destination repository to deploy to.
+   */
+  readonly destinationURI: string;
+
+  /**
+   * The tag of the deployed image.
+   * Defaults to the tag of the source if not provided.
+   */
+  readonly destinationTag?: string;
+}
+
+export interface DestinationProps {
+  /**
+    * The destination repository to deploy to.
+    */
+  readonly repository: ecr.IRepository;
+
+  /**
+    * The tag of the deployed image.
+    * Defaults to the tag of the source if not provided.
+    */
+  readonly tag?: string;
+}
+
+export class Destination {
+  public static ecr(destinationProps: DestinationProps): DestinationConfig {
+    return {
+      destinationURI: destinationProps.repository.repositoryUri,
+      destinationTag: destinationProps.tag,
+    };
+  };
+
+  private constructor () {}
+}

--- a/src/docker-image-deployment.ts
+++ b/src/docker-image-deployment.ts
@@ -1,0 +1,112 @@
+//import * as path from 'path';
+import { Stack } from 'aws-cdk-lib';
+import * as codebuild from 'aws-cdk-lib/aws-codebuild';
+//import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as cr from 'aws-cdk-lib/custom-resources';
+import { Construct } from 'constructs';
+import { DestinationConfig } from './destination';
+import { ISource, SourceConfig } from './source';
+
+
+export interface DockerImageDeploymentProps {
+  /**
+   * Source of image to deploy.
+   */
+  readonly source: ISource;
+
+  /**
+   * Destination repository to deploy the image to.
+   */
+  readonly destination: DestinationConfig;
+}
+
+export class DockerImageDeployment extends Construct {
+  private readonly cb: codebuild.Project;
+
+  constructor(scope: Construct, id: string, props: DockerImageDeploymentProps) {
+    super(scope, id);
+
+
+    const codebuildrole = new iam.Role(this, 'codebuildroleUniqueID', {
+      assumedBy: new iam.ServicePrincipal('codebuild.amazonaws.com'),
+      roleName: 'codebuildrole',
+    });
+    codebuildrole.addToPolicy(new iam.PolicyStatement({
+      actions: [
+        'ecr:BatchCheckLayerAvailability',
+        'ecr:CompleteLayerUpload',
+        'ecr:GetAuthorizationToken',
+        'ecr:InitiateLayerUpload',
+        'ecr:PutImage',
+        'ecr:UploadLayerPart',
+        'ecr:GetDownloadUrlForLayer',
+        'ecr:BatchGetImage',
+        'ecr:BatchCheckLayerAvailability',
+      ],
+      resources: ['*'],
+    }));
+
+
+    // should put these in a function
+
+    // is this necessary?
+    // try doing this without role
+    // is this the right role if the bind is needed?
+    const sourceConfig: SourceConfig = props?.source.bind(this, { handlerRole: codebuildrole });
+    const sourceURI: string = sourceConfig.imageURI;
+
+    let destURI: string = props.destination.destinationURI + ':';
+
+    if (props.destination.destinationTag === undefined) {
+      destURI += sourceConfig.imageTag;
+    } else {
+      destURI += props.destination.destinationTag;
+    }
+
+    // think about why we need these
+    // will there need to be a logout and login for pushing somewhere else - probably, can address with source / dest interfaces
+    const accountId: string = Stack.of(this).account;
+    const region: string = Stack.of(this).region;
+
+
+    const commandList = [
+      `aws ecr get-login-password --region ${region} | docker login --username AWS --password-stdin ${accountId}.dkr.ecr.${region}.amazonaws.com`,
+      `docker pull ${sourceURI}`,
+      `docker tag ${sourceURI} ${destURI}`,
+      `docker push ${destURI}`,
+    ];
+
+
+    // need to think about staging
+    this.cb = new codebuild.Project(this, 'codebuildUniqueID', {
+      buildSpec: codebuild.BuildSpec.fromObject({
+        // version: '0.2'?
+        version: '0.2',
+        phases: {
+          build: {
+            commands: commandList,
+          },
+        },
+      }),
+      environment: { privileged: true, buildImage: codebuild.LinuxBuildImage.STANDARD_5_0 },
+      role: codebuildrole,
+
+    });
+
+    new cr.AwsCustomResource(this, 'startcodebuildUniqueID', {
+      onCreate: {
+        service: 'CodeBuild',
+        action: 'startBuild',
+        parameters: {
+          projectName: this.cb.projectName,
+        },
+        physicalResourceId: cr.PhysicalResourceId.of(Date.now().toString()),
+      },
+      policy: cr.AwsCustomResourcePolicy.fromSdkCalls({
+        resources: cr.AwsCustomResourcePolicy.ANY_RESOURCE,
+      }),
+    });
+
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export * from './docker-image-deployment';
+export * from './source';
+export * from './destination';

--- a/src/source.ts
+++ b/src/source.ts
@@ -1,0 +1,112 @@
+//import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as ecr_assets from 'aws-cdk-lib/aws-ecr-assets';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+
+
+export interface SourceConfig {
+  /**
+   * The source imageURI.
+   */
+  readonly imageURI: string;
+
+  /**
+   * The source tag.
+   */
+  readonly imageTag: string;
+}
+
+// is this needed?
+/**
+ * Bind context for ISources
+ */
+export interface DeploymentSourceContext {
+  /**
+   * The role for the handler
+   */
+  readonly handlerRole: iam.IRole;
+}
+
+// needs to be called ISource since 'Interface contains behavior'
+export interface ISource {
+  /**
+   * Binds the source to a docker image deployment.
+   * @param scope The construct tree context.
+   */
+  bind(scope: Construct, context?: DeploymentSourceContext): SourceConfig;
+}
+
+export class Source {
+  public static directory(path: string): ISource { // TODO: add build props
+    return {
+      bind(scope: Construct, context?: DeploymentSourceContext): SourceConfig {
+        if (!context) {
+          throw new Error('To use a Source.directory(), context must be provided');
+        }
+
+        let id = 1;
+        while (scope.node.tryFindChild(`Assets${id}`)) {
+          id += 1;
+        }
+
+        const asset = new ecr_assets.DockerImageAsset(scope, `Asset${id}`, {
+          directory: path,
+        });
+
+        // does there need to be a validation check here? I dont think so since it will fail at synth time if image is not found at path
+
+        return {
+          imageURI: asset.imageUri,
+          imageTag: asset.assetHash,
+        };
+      },
+    };
+  }
+
+  // TODO: add more sources
+  /*
+  // untested
+  public static asset(asset: ecr_assets.DockerImageAsset): ISource {
+    return {
+      bind(_: Construct, context?: DeploymentSourceContext): SourceConfig {
+        if (!context) {
+          throw new Error('To use a Source.asset(), context must be provided');
+        }
+
+        return {
+          login: { sourceLocation: sourceLocations.ECR},
+          imageURI: asset.imageUri
+        };
+      },
+    };
+  }
+
+  // untested
+  public static ecr(repository: ecr.IRepository, tag: string): ISource {
+    return {
+      bind(_: Construct, context?: DeploymentSourceContext): SourceConfig {
+        if (!context) {
+          throw new Error('To use a Source.ecr(), context must be provided');
+        }
+
+        return {
+          login: { sourceLocation: sourceLocations.ECR, ecrRegion: repository.env.region ,ecrAccount: repository.env.account},
+          imageURI: repository.repositoryUriForTag(tag)
+        };
+      },
+    };
+  }
+
+  // this will need to do a completely different operation than directory, asset, and ecr
+  // needs to download tar/zip file
+  // load with docker load
+  // tag using name (might not be hard)
+  // then push
+
+  public s3(bucket: s3.IBucket, zipObjectKey: string): ISource {
+
+  }
+  */
+
+  private constructor () {}
+}


### PR DESCRIPTION
`docker-image-deploy.ts` is the main module file. It creates an iam Role, a Codebuild job, and an AWS custom resource. It gets a source from `source.ts` and a destination from `destination.ts`. Currently, it supports deploying a local Dockerfile to an ecr repository in the same region and account as the stack.

The example app is in the `/src/app` folder. `app.ts` shows how a user would call this construct. 

To run the example app, you will need to create a repository in ECR and pass its name into destination. Then run `yarn build` and `cdk deploy --app lib/app/runner.js` to deploy the stack and see the image in that repository.

Known bugs / ugliness:
* cannot call the construct twice in the same app
* destination API could be improved from creating an entire ecr object
* takes a long time to deploy