### PR TITLE
fix: code references files that are not released with the library

### DIFF
--- a/src/docker-image-deployment.ts
+++ b/src/docker-image-deployment.ts
@@ -75,13 +75,13 @@ export class DockerImageDeployment extends Construct {
     });
 
     const onEventHandler = new lambda.NodejsFunction(this, 'onEventHandler', {
-      entry: path.join(__dirname, 'codebuild-handler/index.ts'),
+      entry: path.join(__dirname, 'codebuild-handler/index.js'),
       handler: 'onEventhandler',
       runtime: Runtime.NODEJS_16_X,
     });
 
     const isCompleteHandler = new lambda.NodejsFunction(this, 'isCompleteHandler', {
-      entry: path.join(__dirname, 'codebuild-handler/index.ts'),
+      entry: path.join(__dirname, 'codebuild-handler/index.js'),
       handler: 'isCompleteHandler',
       runtime: Runtime.NODEJS_16_X,
     });

--- a/test/docker-image-deploy.test.ts
+++ b/test/docker-image-deploy.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as cdk from 'aws-cdk-lib/core';
-import * as imagedeploy from '../src';
+import * as imagedeploy from '../lib/index';
 
 describe('DockerImageDeploy', () => {
   // GIVEN


### PR DESCRIPTION
I'm getting this error when trying to use the library:

```
Error: Cannot find entry file at /.../node_modules/cdk-docker-image-deployment/lib/codebuild-handler/index.ts
```

Probably because we don't export `index.ts`, only `index.js`. Alternatively we could just include the `index.ts` file in the packaged library, but this seems easier.