### PR TITLE
introduced new source `dockerImageAssetProps`

### DIFF
--- a/API.md
+++ b/API.md
@@ -583,6 +583,7 @@ Bind should be invoked by the caller to get the SourceConfig.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-docker-image-deployment.Source.directory">directory</a></code> | Uses a local image built from a Dockerfile in a local directory as the source. |
+| <code><a href="#cdk-docker-image-deployment.Source.dockerImageAssetProps">dockerImageAssetProps</a></code> | Uses a local image built from a Dockerfile in a local directory as the source. |
 
 ---
 
@@ -601,6 +602,24 @@ Uses a local image built from a Dockerfile in a local directory as the source.
 - *Type:* string
 
 path to the directory containing your Dockerfile (not a path to a file).
+
+---
+
+##### `dockerImageAssetProps` <a name="dockerImageAssetProps" id="cdk-docker-image-deployment.Source.dockerImageAssetProps"></a>
+
+```typescript
+import { Source } from 'cdk-docker-image-deployment'
+
+Source.dockerImageAssetProps(dockerImageAssetProps: DockerImageAssetProps)
+```
+
+Uses a local image built from a Dockerfile in a local directory as the source.
+
+###### `dockerImageAssetProps`<sup>Required</sup> <a name="dockerImageAssetProps" id="cdk-docker-image-deployment.Source.dockerImageAssetProps.parameter.dockerImageAssetProps"></a>
+
+- *Type:* aws-cdk-lib.aws_ecr_assets.DockerImageAssetProps
+
+everything from [DockerImageAssetProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecr_assets.DockerImageAssetProps.html).
 
 ---
 

--- a/src/source.ts
+++ b/src/source.ts
@@ -53,7 +53,18 @@ export abstract class Source {
    * @param path - path to the directory containing your Dockerfile (not a path to a file)
    */
   public static directory(path: string): Source {
-    return new DirectorySource(path);
+    return new DockerImageAssetPropsSource({ directory: path });
+  }
+
+  /**
+   * Uses a local image built from a Dockerfile in a local directory as the source.
+   *
+   * @param dockerImageAssetProps - everything from [DockerImageAssetProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecr_assets.DockerImageAssetProps.html)
+   */
+  public static dockerImageAssetProps(
+    dockerImageAssetProps: ecr_assets.DockerImageAssetProps,
+  ): Source {
+    return new DockerImageAssetPropsSource(dockerImageAssetProps);
   }
 
   /**
@@ -66,19 +77,20 @@ export abstract class Source {
 /**
  * Source of docker image deployment is a local image from a directory
  */
-class DirectorySource extends Source {
-  private path: string;
+class DockerImageAssetPropsSource extends Source {
+  private assetProps: ecr_assets.DockerImageAssetProps;
 
-  constructor(path: string) {
+  constructor(assetProps: ecr_assets.DockerImageAssetProps) {
     super();
-    this.path = path;
+    this.assetProps = assetProps;
   }
 
   public bind(scope: Construct, context: SourceContext): SourceConfig {
-
-    const asset = new ecr_assets.DockerImageAsset(scope, 'asset', {
-      directory: this.path,
-    });
+    const asset = new ecr_assets.DockerImageAsset(
+      scope,
+      'asset',
+      this.assetProps,
+    );
 
     const accountId = asset.repository.env.account;
     const region = asset.repository.env.region;


### PR DESCRIPTION
As described in #194 it would be nice to use all the options from [DockeImageAssetProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecr_assets.DockerImageAssetProps.html) to configure a local docker build. We for example need to specify a special Dockerfile, and not the default one.
