### PR TITLE
fix(test): use aws-cdk-lib root import instead of removed /core subpath

### DIFF
--- a/test/docker-image-deploy.test.ts
+++ b/test/docker-image-deploy.test.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
 import * as imagedeploy from '../lib/index';
 
 describe('DockerImageDeploy', () => {

--- a/test/docker-image-deploy.test.ts
+++ b/test/docker-image-deploy.test.ts
@@ -1,8 +1,8 @@
 // imports
 import * as path from 'path';
+import * as cdk from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
-import * as cdk from 'aws-cdk-lib';
 import * as imagedeploy from '../lib/index';
 
 describe('DockerImageDeploy', () => {


### PR DESCRIPTION
## Problem

The daily `chore(deps): upgrade dependencies` PR (#1275) has been stuck unmerged because its `build` check fails at the `test` step:

```
test/docker-image-deploy.test.ts:5:22 - error TS2307: Cannot find module 'aws-cdk-lib/core' or its corresponding type declarations.
5 import * as cdk from 'aws-cdk-lib/core';
```

The upgraded `aws-cdk-lib` no longer exposes the `aws-cdk-lib/core` deep-import subpath.

## Fix

`Stack` (the only symbol used from `cdk` in this file) is exported from the `aws-cdk-lib` root, so import from there instead.

## Verification

- `npx projen compile` → 0 errors
- `npx jest test/docker-image-deploy.test.ts` → 14 passed, 1 suite passed

Once merged to `main`, the nightly upgrade workflow will regenerate #1275 on top of this fix and it should build and auto-merge, resolving the stale-PR alarm.